### PR TITLE
fix: objectToCamel return type when the input is a snake-typed array

### DIFF
--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -110,7 +110,7 @@ export type ObjectToCamel<T extends object | undefined | null> =
     ? null
     : T extends Array<infer ArrayType>
     ? ArrayType extends object
-      ? Array<ObjectToPascal<ArrayType>>
+      ? Array<ObjectToCamel<ArrayType>>
       : Array<ArrayType>
     : {
         [K in keyof T as ToCamel<K>]: T[K] extends

--- a/test/caseConvert.bugs.test.ts
+++ b/test/caseConvert.bugs.test.ts
@@ -2,6 +2,7 @@ import {
   ObjectToCamel,
   ObjectToPascal,
   ObjectToSnake,
+  objectToCamel
 } from '../src/caseConvert';
 
 describe('bug fixes', () => {
@@ -72,6 +73,21 @@ describe('bug fixes', () => {
     snakeRequest.object_array?.forEach((value) => {
       expect(value.index).toEqual(0);
     });
+  });
+
+  it('#52 - objectToCamel return type is a Pascal-cased array when the input is a snake-typed array', () => {
+    type SnakeTyped = { key: string; another_key: string }
+    type CamelType = { key: string; anotherKey: string }
+
+    const snakeObject: SnakeTyped[] = [
+      { key: 'a', another_key: 'b' },
+    ];
+
+    const camelObject: CamelType[] = objectToCamel(snakeObject);
+
+    expect(Object.keys(camelObject[0])).toEqual(['key', 'anotherKey']);
+    expect(camelObject[0].key).toEqual('a');
+    expect(camelObject[0].anotherKey).toEqual('b');
   });
 });
 


### PR DESCRIPTION
Fixes #52.