### PR TITLE
fix: prevent Buffer values from being converted as Objects

### DIFF
--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -16,7 +16,7 @@ function convertObject<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     out[keyConverter(k)] = Array.isArray(v)
       ? (v.map(<ArrayItem extends object>(item: ArrayItem) =>
-          typeof item === 'object'
+          typeof item === 'object' && !Buffer.isBuffer(item)
             ? convertObject<
                 ArrayItem,
                 TResult extends ObjectToCamel<TInput>
@@ -27,6 +27,8 @@ function convertObject<
               >(item, keyConverter)
             : item,
         ) as unknown[])
+      : Buffer.isBuffer(v)
+      ? v
       : typeof v === 'object'
       ? convertObject<
           typeof v,
@@ -118,6 +120,8 @@ export type ObjectToCamel<T extends object | undefined | null> =
     ? ArrayType extends object
       ? Array<ObjectToCamel<ArrayType>>
       : Array<ArrayType>
+    : T extends Buffer
+    ? Buffer
     : {
         [K in keyof T as ToCamel<K>]: T[K] extends
           | Array<infer ArrayType>
@@ -148,6 +152,8 @@ export type ObjectToPascal<T extends object | undefined | null> =
     ? ArrayType extends object
       ? Array<ObjectToPascal<ArrayType>>
       : Array<ArrayType>
+    : T extends Buffer
+    ? Buffer
     : {
         [K in keyof T as ToPascal<K>]: T[K] extends
           | Array<infer ArrayType>
@@ -212,6 +218,8 @@ export type ObjectToSnake<T extends object | undefined | null> =
     ? ArrayType extends object
       ? Array<ObjectToSnake<ArrayType>>
       : Array<ArrayType>
+    : T extends Buffer
+    ? Buffer
     : {
         [K in keyof T as ToSnake<K>]: T[K] extends
           | Array<infer ArrayType>

--- a/test/caseConvert.bugs.test.ts
+++ b/test/caseConvert.bugs.test.ts
@@ -3,6 +3,7 @@ import {
   ObjectToPascal,
   ObjectToSnake,
   objectToCamel,
+  objectToSnake,
 } from '../src/caseConvert';
 
 describe('bug fixes', () => {
@@ -100,6 +101,22 @@ describe('bug fixes', () => {
     const camelScalarArray = objectToCamel([1]);
     expect(Array.isArray(camelScalarArray)).toBe(true);
   });
+
+    it('#58 - does not handle Buffer objects correctly', () => {
+        const snakeObject = { buffer_key: Buffer.from('abc'), nested: { more_nested: Buffer.from('abc') }, array: [Buffer.from('abc')] };
+        const convertedSnakeObj = objectToCamel(snakeObject);
+
+        expect(Buffer.isBuffer(convertedSnakeObj.bufferKey)).toBeTruthy();
+        expect(Buffer.isBuffer(convertedSnakeObj.nested.moreNested)).toBeTruthy();
+        expect(Buffer.isBuffer(convertedSnakeObj.array[0])).toBeTruthy();
+
+        const camelObject = { bufferKey: Buffer.from('abc'), nested: { moreNested: Buffer.from('abc') }, array: [Buffer.from('abc')] };
+        const convertedCamelObject = objectToSnake(camelObject);
+
+        expect(Buffer.isBuffer(convertedCamelObject.buffer_key)).toBeTruthy();
+        expect(Buffer.isBuffer(convertedCamelObject.nested.more_nested)).toBeTruthy();
+        expect(Buffer.isBuffer(convertedCamelObject.array[0])).toBeTruthy();
+    });
 });
 
 // Bug #50


### PR DESCRIPTION
Fixes #58. Adds a specific check for whether a field value is a `Buffer` so that it's not caught by the `Object` conversion process which is currently mangling the `Buffer` data