### PR TITLE
fix: prevent failure when Buffer is not defined (such as within browsers)

### DIFF
--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -9,6 +9,7 @@ function convertObject<
     return obj;
   }
 
+  const isBufferDefined = typeof Buffer !== 'undefined';
   const out = (Array.isArray(obj) ? [] : {}) as TResult;
   for (const [k, v] of Object.entries(obj)) {
     // eslint-disable-next-line
@@ -16,7 +17,7 @@ function convertObject<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     out[keyConverter(k)] = Array.isArray(v)
       ? (v.map(<ArrayItem extends object>(item: ArrayItem) =>
-          typeof item === 'object' && !Buffer.isBuffer(item)
+          typeof item === 'object' && (!isBufferDefined || !Buffer.isBuffer(item))
             ? convertObject<
                 ArrayItem,
                 TResult extends ObjectToCamel<TInput>
@@ -27,7 +28,7 @@ function convertObject<
               >(item, keyConverter)
             : item,
         ) as unknown[])
-      : Buffer.isBuffer(v)
+      : isBufferDefined && Buffer.isBuffer(v)
       ? v
       : typeof v === 'object'
       ? convertObject<


### PR DESCRIPTION
Fixes #60

Buffer doesn't exist within browsers, causing the error `ReferenceError: Buffer is not defined`. This PR prevents this error from occurring.

I would have added a test, but I can't find an effective way of overriding the Buffer global when tests are run.

Thanks!