### PR TITLE
chore: export types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,11 @@ export {
   toPascal,
   objectToPascal,
 } from './caseConvert';
+export type {
+	ObjectToCamel,
+	ObjectToPascal,
+	ObjectToSnake,
+	ToCamel,
+	ToPascal,
+	ToSnake,
+} from './caseConvert';


### PR DESCRIPTION
Would be really helpful to have access to these types from the barrel file so we can use them in our code.