### PR TITLE
fix: preserve Date values in objectToCamel

### DIFF
--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -29,7 +29,7 @@ function convertObject<
         ) as unknown[])
       : Buffer.isBuffer(v)
       ? v
-      : typeof v === 'object'
+      : typeof v === 'object' && !(v instanceof Date)
       ? convertObject<
           typeof v,
           TResult extends ObjectToCamel<TInput>

--- a/test/caseConvert.bugs.test.ts
+++ b/test/caseConvert.bugs.test.ts
@@ -117,6 +117,16 @@ describe('bug fixes', () => {
         expect(Buffer.isBuffer(convertedCamelObject.nested.more_nested)).toBeTruthy();
         expect(Buffer.isBuffer(convertedCamelObject.array[0])).toBeTruthy();
     });
+
+    it('#71 - objectToCamel does not handle Date fields properly', () => {
+      const dateValue = new Date();
+      const snakeObject = { date_field: dateValue, nested_object_field: { date_field: dateValue } };
+
+      const camelObject = objectToCamel(snakeObject);
+
+      expect(camelObject.dateField).toEqual(dateValue);
+      expect(camelObject.nestedObjectField.dateField).toEqual(dateValue);
+    });
 });
 
 // Bug #50


### PR DESCRIPTION
Currently objectToCamel does not preserve dates when converting.
Here are [details](https://github.com/RossWilliams/ts-case-convert/issues/71)

This PR solves the issue

