### PR TITLE
fix: Corrected ObjectToCamel, ObjectToPascal, ObjectToSnake types

### DIFF
--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -111,7 +111,7 @@ export type ToCamel<S extends string | number | symbol> = S extends string
     : S extends `${infer Head}-${infer Tail}`
     ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
     : Uncapitalize<S>
-    : never;
+  : never;
 
 export type ObjectToCamel<T extends object | undefined | null> =
   T extends undefined
@@ -127,14 +127,14 @@ export type ObjectToCamel<T extends object | undefined | null> =
     : T extends Date
     ? Date
     : {
-      [K in keyof T as ToCamel<K>]: T[K] extends Array<infer ArrayType extends string | number>
-      ? Array<ArrayType>
-      : T extends Array<infer ArrayType extends object>
-      ? Array<ObjectToCamel<ArrayType>>
-      : T[K] extends object | undefined | null
-      ? ObjectToCamel<T[K]>
-      : T[K];
-    };
+        [K in keyof T as ToCamel<K>]: T[K] extends Array<infer ArrayType extends string | number>
+          ? Array<ArrayType>
+          : T extends Array<infer ArrayType extends object>
+          ? Array<ObjectToCamel<ArrayType>>
+          : T[K] extends object | undefined | null
+          ? ObjectToCamel<T[K]>
+          : T[K];
+        };
 
 export type ToPascal<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
@@ -142,7 +142,7 @@ export type ToPascal<S extends string | number | symbol> = S extends string
     : S extends `${infer Head}-${infer Tail}`
     ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
     : Capitalize<S>
-    : never;
+  : never;
 
 export type ObjectToPascal<T extends object | undefined | null> =
   T extends undefined
@@ -151,21 +151,21 @@ export type ObjectToPascal<T extends object | undefined | null> =
     ? null
     : T extends Array<infer ArrayType extends string | number>
     ? Array<ArrayType>
-      : T extends Array<infer ArrayType extends object>
-      ? Array<ObjectToPascal<ArrayType>>
+    : T extends Array<infer ArrayType extends object>
+    ? Array<ObjectToPascal<ArrayType>>
     : T extends Uint8Array
     ? Uint8Array
     : T extends Date
     ? Date
     : {
-      [K in keyof T as ToPascal<K>]: T[K] extends Array<infer ArrayType extends string | number>
-        ? Array<ArrayType>
-        : T extends Array<infer ArrayType extends object>
-        ? Array<ObjectToPascal<ArrayType>>
-        : T[K] extends object | undefined | null
-        ? ObjectToPascal<T[K]>
-        : T[K];
-    };
+        [K in keyof T as ToPascal<K>]: T[K] extends Array<infer ArrayType extends string | number>
+          ? Array<ArrayType>
+          : T extends Array<infer ArrayType extends object>
+          ? Array<ObjectToPascal<ArrayType>>
+          : T[K] extends object | undefined | null
+          ? ObjectToPascal<T[K]>
+          : T[K];
+      };
 
 export type ToSnake<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}${CapitalChars}${infer Tail}` // string has a capital char somewhere
@@ -211,7 +211,7 @@ export type ToSnake<S extends string | number | symbol> = S extends string
           : never
         : never
       : never
-  : S /* 'abc'  */
+    : S /* 'abc'  */
   : never;
 
 export type ObjectToSnake<T extends object | undefined | null> =
@@ -235,7 +235,7 @@ export type ObjectToSnake<T extends object | undefined | null> =
           : T[K] extends object | undefined | null
           ? ObjectToSnake<T[K]>
           : T[K];
-    };
+      };
 
 type CapitalLetters =
   | 'A'

--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -1,9 +1,9 @@
 function convertObject<
   TInput extends object,
   TResult extends
-  | ObjectToCamel<TInput>
-  | ObjectToSnake<TInput>
-  | ObjectToPascal<TInput>,
+    | ObjectToCamel<TInput>
+    | ObjectToSnake<TInput>
+    | ObjectToPascal<TInput>,
 >(obj: TInput, keyConverter: (arg: string) => string): TResult {
   if (obj === null || typeof obj === 'undefined' || typeof obj !== 'object') {
     return obj;
@@ -16,31 +16,31 @@ function convertObject<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     out[keyConverter(k)] = Array.isArray(v)
       ? (v.map(<ArrayItem extends object>(item: ArrayItem) =>
-        typeof item === 'object' &&
+          typeof item === 'object' &&
           !(item instanceof Uint8Array) &&
           !(item instanceof Date)
-          ? convertObject<
-            ArrayItem,
-            TResult extends ObjectToCamel<TInput>
-            ? ObjectToCamel<ArrayItem>
-            : TResult extends ObjectToPascal<TInput>
-            ? ObjectToPascal<ArrayItem>
-            : ObjectToSnake<ArrayItem>
-          >(item, keyConverter)
-          : item,
-      ) as unknown[])
+            ? convertObject<
+                ArrayItem,
+                TResult extends ObjectToCamel<TInput>
+                  ? ObjectToCamel<ArrayItem>
+                  : TResult extends ObjectToPascal<TInput>
+                  ? ObjectToPascal<ArrayItem>
+                  : ObjectToSnake<ArrayItem>
+              >(item, keyConverter)
+            : item,
+        ) as unknown[])
       : v instanceof Uint8Array || v instanceof Date
-        ? v
-        : typeof v === 'object'
-          ? convertObject<
-            typeof v,
-            TResult extends ObjectToCamel<TInput>
+      ? v
+      : typeof v === 'object'
+      ? convertObject<
+          typeof v,
+          TResult extends ObjectToCamel<TInput>
             ? ObjectToCamel<typeof v>
             : TResult extends ObjectToPascal<TInput>
             ? ObjectToPascal<typeof v>
             : ObjectToSnake<typeof v>
-          >(v, keyConverter)
-          : (v as unknown);
+        >(v, keyConverter)
+      : (v as unknown);
   }
   return out;
 }
@@ -50,8 +50,8 @@ export function toCamel<T extends string>(term: T): ToCamel<T> {
     term.length === 1
       ? term.toLowerCase()
       : term
-        .replace(/^([A-Z])/, (m) => m[0].toLowerCase())
-        .replace(/[_-]([a-z0-9])/g, (m) => m[1].toUpperCase())
+          .replace(/^([A-Z])/, (m) => m[0].toLowerCase())
+          .replace(/[_-]([a-z0-9])/g, (m) => m[1].toUpperCase())
   ) as ToCamel<T>;
 }
 
@@ -107,134 +107,135 @@ export function objectToPascal<T extends object>(obj: T): ObjectToPascal<T> {
 
 export type ToCamel<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
-  ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
-  : S extends `${infer Head}-${infer Tail}`
-  ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
-  : Uncapitalize<S>
-  : never;
+    ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
+    : S extends `${infer Head}-${infer Tail}`
+    ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
+    : Uncapitalize<S>
+    : never;
 
 export type ObjectToCamel<T extends object | undefined | null> =
   T extends undefined
-  ? undefined
-  : T extends null
-  ? null
-  : T extends Array<infer ArrayType extends string | number>
-  ? Array<ArrayType>
-  : T extends Array<infer ArrayType extends object>
-  ? Array<ObjectToCamel<ArrayType>>
-  : T extends Uint8Array
-  ? Uint8Array
-  : T extends Date
-  ? Date
-  : {
-    [K in keyof T as ToCamel<K>]: T[K] extends Array<infer ArrayType extends string | number>
+    ? undefined
+    : T extends null
+    ? null
+    : T extends Array<infer ArrayType extends string | number>
     ? Array<ArrayType>
     : T extends Array<infer ArrayType extends object>
     ? Array<ObjectToCamel<ArrayType>>
-    : T[K] extends object | undefined | null
-    ? ObjectToCamel<T[K]>
-    : T[K];
-  };
+    : T extends Uint8Array
+    ? Uint8Array
+    : T extends Date
+    ? Date
+    : {
+      [K in keyof T as ToCamel<K>]: T[K] extends Array<infer ArrayType extends string | number>
+      ? Array<ArrayType>
+      : T extends Array<infer ArrayType extends object>
+      ? Array<ObjectToCamel<ArrayType>>
+      : T[K] extends object | undefined | null
+      ? ObjectToCamel<T[K]>
+      : T[K];
+    };
 
 export type ToPascal<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
-  ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
-  : S extends `${infer Head}-${infer Tail}`
-  ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
-  : Capitalize<S>
-  : never;
+    ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
+    : S extends `${infer Head}-${infer Tail}`
+    ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
+    : Capitalize<S>
+    : never;
 
 export type ObjectToPascal<T extends object | undefined | null> =
   T extends undefined
-  ? undefined
-  : T extends null
-  ? null
-  : T extends Array<infer ArrayType extends string | number>
-  ? Array<ArrayType>
-  : T extends Array<infer ArrayType extends object>
-  ? Array<ObjectToPascal<ArrayType>>
-  : T extends Uint8Array
-  ? Uint8Array
-  : T extends Date
-  ? Date
-  : {
-    [K in keyof T as ToPascal<K>]: T[K] extends Array<infer ArrayType extends string | number>
+    ? undefined
+    : T extends null
+    ? null
+    : T extends Array<infer ArrayType extends string | number>
     ? Array<ArrayType>
-    : T extends Array<infer ArrayType extends object>
-    ? Array<ObjectToPascal<ArrayType>>
-    : T[K] extends object | undefined | null
-    ? ObjectToPascal<T[K]>
-    : T[K];
-  };
+      : T extends Array<infer ArrayType extends object>
+      ? Array<ObjectToPascal<ArrayType>>
+    : T extends Uint8Array
+    ? Uint8Array
+    : T extends Date
+    ? Date
+    : {
+      [K in keyof T as ToPascal<K>]: T[K] extends Array<infer ArrayType extends string | number>
+        ? Array<ArrayType>
+        : T extends Array<infer ArrayType extends object>
+        ? Array<ObjectToPascal<ArrayType>>
+        : T[K] extends object | undefined | null
+        ? ObjectToPascal<T[K]>
+        : T[K];
+    };
 
 export type ToSnake<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}${CapitalChars}${infer Tail}` // string has a capital char somewhere
-  ? Head extends '' // there is a capital char in the first position
-  ? Tail extends ''
-  ? Lowercase<S> /*  'A' */
-  : S extends `${infer Caps}${Tail}` // tail exists, has capital characters
-  ? Caps extends CapitalChars
-  ? Tail extends CapitalLetters
-  ? `${Lowercase<Caps>}_${Lowercase<Tail>}` /* 'AB' */
-  : Tail extends `${CapitalLetters}${string}`
-  ? `${ToSnake<Caps>}_${ToSnake<Tail>}` /* first tail char is upper? 'ABcd' */
-  : `${ToSnake<Caps>}${ToSnake<Tail>}` /* 'AbCD','AbcD',  */ /* TODO: if tail is only numbers, append without underscore */
-  : never /* never reached, used for inference of caps */
-  : never
-  : Tail extends '' /* 'aB' 'abCD' 'ABCD' 'AB' */
-  ? S extends `${Head}${infer Caps}`
-  ? Caps extends CapitalChars
-  ? Head extends Lowercase<Head> /* 'abcD' */
-  ? Caps extends Numbers
-  ? // Head exists and is lowercase, tail does not, Caps is a number, we may be in a sub-select
-  // if head ends with number, don't split head an Caps, keep contiguous numbers together
-  Head extends `${string}${Numbers}`
-  ? never
-  : // head does not end in number, safe to split. 'abc2' -> 'abc_2'
-  `${ToSnake<Head>}_${Caps}`
-  : `${ToSnake<Head>}_${ToSnake<Caps>}` /* 'abcD' 'abc25' */
-  : never /* stop union type forming */
-  : never
-  : never /* never reached, used for inference of caps */
-  : S extends `${Head}${infer Caps}${Tail}` /* 'abCd' 'ABCD' 'AbCd' 'ABcD' */
-  ? Caps extends CapitalChars
-  ? Head extends Lowercase<Head> /* is 'abCd' 'abCD' ? */
-  ? Tail extends CapitalLetters /* is 'abCD' where Caps = 'C' */
-  ? `${ToSnake<Head>}_${ToSnake<Caps>}_${Lowercase<Tail>}` /* aBCD Tail = 'D', Head = 'aB' */
-  : Tail extends `${CapitalLetters}${string}` /* is 'aBCd' where Caps = 'B' */
-  ? Head extends Numbers
-  ? never /* stop union type forming */
-  : Head extends `${string}${Numbers}`
-  ? never /* stop union type forming */
-  : `${Head}_${ToSnake<Caps>}_${ToSnake<Tail>}` /* 'aBCd' => `${'a'}_${Lowercase<'B'>}_${ToSnake<'Cd'>}` */
-  : `${ToSnake<Head>}_${Lowercase<Caps>}${ToSnake<Tail>}` /* 'aBcD' where Caps = 'B' tail starts as lowercase */
-  : never
-  : never
-  : never
+    ? Head extends '' // there is a capital char in the first position
+      ? Tail extends ''
+        ? Lowercase<S> /*  'A' */
+        : S extends `${infer Caps}${Tail}` // tail exists, has capital characters
+        ? Caps extends CapitalChars
+          ? Tail extends CapitalLetters
+            ? `${Lowercase<Caps>}_${Lowercase<Tail>}` /* 'AB' */
+            : Tail extends `${CapitalLetters}${string}`
+            ? `${ToSnake<Caps>}_${ToSnake<Tail>}` /* first tail char is upper? 'ABcd' */
+            : `${ToSnake<Caps>}${ToSnake<Tail>}` /* 'AbCD','AbcD',  */ /* TODO: if tail is only numbers, append without underscore */
+          : never /* never reached, used for inference of caps */
+        : never
+      : Tail extends '' /* 'aB' 'abCD' 'ABCD' 'AB' */
+      ? S extends `${Head}${infer Caps}`
+        ? Caps extends CapitalChars
+          ? Head extends Lowercase<Head> /* 'abcD' */
+            ? Caps extends Numbers
+              ? // Head exists and is lowercase, tail does not, Caps is a number, we may be in a sub-select
+                // if head ends with number, don't split head an Caps, keep contiguous numbers together
+                Head extends `${string}${Numbers}`
+                ? never
+                : // head does not end in number, safe to split. 'abc2' -> 'abc_2'
+                  `${ToSnake<Head>}_${Caps}`
+              : `${ToSnake<Head>}_${ToSnake<Caps>}` /* 'abcD' 'abc25' */
+            : never /* stop union type forming */
+          : never
+        : never /* never reached, used for inference of caps */
+      : S extends `${Head}${infer Caps}${Tail}` /* 'abCd' 'ABCD' 'AbCd' 'ABcD' */
+      ? Caps extends CapitalChars
+        ? Head extends Lowercase<Head> /* is 'abCd' 'abCD' ? */
+          ? Tail extends CapitalLetters /* is 'abCD' where Caps = 'C' */
+            ? `${ToSnake<Head>}_${ToSnake<Caps>}_${Lowercase<Tail>}` /* aBCD Tail = 'D', Head = 'aB' */
+            : Tail extends `${CapitalLetters}${string}` /* is 'aBCd' where Caps = 'B' */
+            ? Head extends Numbers
+              ? never /* stop union type forming */
+              : Head extends `${string}${Numbers}`
+              ? never /* stop union type forming */
+              : `${Head}_${ToSnake<Caps>}_${ToSnake<Tail>}` /* 'aBCd' => `${'a'}_${Lowercase<'B'>}_${ToSnake<'Cd'>}` */
+            : `${ToSnake<Head>}_${Lowercase<Caps>}${ToSnake<Tail>}` /* 'aBcD' where Caps = 'B' tail starts as lowercase */
+          : never
+        : never
+      : never
   : S /* 'abc'  */
   : never;
 
-export type ObjectToSnake<T extends object | undefined | null> = T extends undefined
-  ? undefined
-  : T extends null
-  ? null
-  : T extends Array<infer ArrayType extends string | number>
-  ? Array<ArrayType>
-  : T extends Array<infer ArrayType extends object>
-  ? Array<ObjectToSnake<ArrayType>>
-  : T extends Uint8Array
-  ? Uint8Array
-  : T extends Date
-  ? Date
-  : {
-    [K in keyof T as ToSnake<K>]: T[K] extends Array<infer ArrayType extends string | number>
+export type ObjectToSnake<T extends object | undefined | null> =
+  T extends undefined
+    ? undefined
+    : T extends null
+    ? null
+    : T extends Array<infer ArrayType extends string | number>
     ? Array<ArrayType>
     : T extends Array<infer ArrayType extends object>
-    ? Array<ObjectToPascal<ArrayType>>
-    : T[K] extends object | undefined | null
-    ? ObjectToSnake<T[K]>
-    : T[K];
-  };
+    ? Array<ObjectToSnake<ArrayType>>
+    : T extends Uint8Array
+    ? Uint8Array
+    : T extends Date
+    ? Date
+    : {
+        [K in keyof T as ToSnake<K>]: T[K] extends Array<infer ArrayType extends string | number>
+          ? Array<ArrayType>
+          : T extends Array<infer ArrayType extends object>
+          ? Array<ObjectToPascal<ArrayType>>
+          : T[K] extends object | undefined | null
+          ? ObjectToSnake<T[K]>
+          : T[K];
+    };
 
 type CapitalLetters =
   | 'A'

--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -1,9 +1,9 @@
 function convertObject<
   TInput extends object,
   TResult extends
-    | ObjectToCamel<TInput>
-    | ObjectToSnake<TInput>
-    | ObjectToPascal<TInput>,
+  | ObjectToCamel<TInput>
+  | ObjectToSnake<TInput>
+  | ObjectToPascal<TInput>,
 >(obj: TInput, keyConverter: (arg: string) => string): TResult {
   if (obj === null || typeof obj === 'undefined' || typeof obj !== 'object') {
     return obj;
@@ -16,31 +16,31 @@ function convertObject<
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     out[keyConverter(k)] = Array.isArray(v)
       ? (v.map(<ArrayItem extends object>(item: ArrayItem) =>
-          typeof item === 'object' &&
+        typeof item === 'object' &&
           !(item instanceof Uint8Array) &&
           !(item instanceof Date)
-            ? convertObject<
-                ArrayItem,
-                TResult extends ObjectToCamel<TInput>
-                  ? ObjectToCamel<ArrayItem>
-                  : TResult extends ObjectToPascal<TInput>
-                  ? ObjectToPascal<ArrayItem>
-                  : ObjectToSnake<ArrayItem>
-              >(item, keyConverter)
-            : item,
-        ) as unknown[])
+          ? convertObject<
+            ArrayItem,
+            TResult extends ObjectToCamel<TInput>
+            ? ObjectToCamel<ArrayItem>
+            : TResult extends ObjectToPascal<TInput>
+            ? ObjectToPascal<ArrayItem>
+            : ObjectToSnake<ArrayItem>
+          >(item, keyConverter)
+          : item,
+      ) as unknown[])
       : v instanceof Uint8Array || v instanceof Date
-      ? v
-      : typeof v === 'object'
-      ? convertObject<
-          typeof v,
-          TResult extends ObjectToCamel<TInput>
+        ? v
+        : typeof v === 'object'
+          ? convertObject<
+            typeof v,
+            TResult extends ObjectToCamel<TInput>
             ? ObjectToCamel<typeof v>
             : TResult extends ObjectToPascal<TInput>
             ? ObjectToPascal<typeof v>
             : ObjectToSnake<typeof v>
-        >(v, keyConverter)
-      : (v as unknown);
+          >(v, keyConverter)
+          : (v as unknown);
   }
   return out;
 }
@@ -50,8 +50,8 @@ export function toCamel<T extends string>(term: T): ToCamel<T> {
     term.length === 1
       ? term.toLowerCase()
       : term
-          .replace(/^([A-Z])/, (m) => m[0].toLowerCase())
-          .replace(/[_-]([a-z0-9])/g, (m) => m[1].toUpperCase())
+        .replace(/^([A-Z])/, (m) => m[0].toLowerCase())
+        .replace(/[_-]([a-z0-9])/g, (m) => m[1].toUpperCase())
   ) as ToCamel<T>;
 }
 
@@ -107,144 +107,134 @@ export function objectToPascal<T extends object>(obj: T): ObjectToPascal<T> {
 
 export type ToCamel<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
-    ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
-    : S extends `${infer Head}-${infer Tail}`
-    ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
-    : Uncapitalize<S>
+  ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
+  : S extends `${infer Head}-${infer Tail}`
+  ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
+  : Uncapitalize<S>
   : never;
 
 export type ObjectToCamel<T extends object | undefined | null> =
   T extends undefined
-    ? undefined
-    : T extends null
-    ? null
-    : T extends Array<infer ArrayType>
-    ? ArrayType extends object
-      ? Array<ObjectToCamel<ArrayType>>
-      : Array<ArrayType>
-    : T extends Uint8Array
-    ? Uint8Array
-    : T extends Date
-    ? Date
-    : {
-        [K in keyof T as ToCamel<K>]: T[K] extends
-          | Array<infer ArrayType>
-          | undefined
-          | null
-          ? ArrayType extends object
-            ? Array<ObjectToCamel<ArrayType>>
-            : Array<ArrayType>
-          : T[K] extends object | undefined | null
-          ? ObjectToCamel<T[K]>
-          : T[K];
-      };
+  ? undefined
+  : T extends null
+  ? null
+  : T extends Array<infer ArrayType extends string | number>
+  ? Array<ArrayType>
+  : T extends Array<infer ArrayType extends object>
+  ? Array<ObjectToCamel<ArrayType>>
+  : T extends Uint8Array
+  ? Uint8Array
+  : T extends Date
+  ? Date
+  : {
+    [K in keyof T as ToCamel<K>]: T[K] extends Array<infer ArrayType extends string | number>
+    ? Array<ArrayType>
+    : T extends Array<infer ArrayType extends object>
+    ? Array<ObjectToCamel<ArrayType>>
+    : T[K] extends object | undefined | null
+    ? ObjectToCamel<T[K]>
+    : T[K];
+  };
 
 export type ToPascal<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
-    ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
-    : S extends `${infer Head}-${infer Tail}`
-    ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
-    : Capitalize<S>
+  ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
+  : S extends `${infer Head}-${infer Tail}`
+  ? `${Capitalize<ToCamel<Head>>}${Capitalize<ToCamel<Tail>>}`
+  : Capitalize<S>
   : never;
 
 export type ObjectToPascal<T extends object | undefined | null> =
   T extends undefined
-    ? undefined
-    : T extends null
-    ? null
-    : T extends Array<infer ArrayType>
-    ? ArrayType extends object
-      ? Array<ObjectToPascal<ArrayType>>
-      : Array<ArrayType>
-    : T extends Uint8Array
-    ? Uint8Array
-    : T extends Date
-    ? Date
-    : {
-        [K in keyof T as ToPascal<K>]: T[K] extends
-          | Array<infer ArrayType>
-          | undefined
-          | null
-          ? ArrayType extends object
-            ? Array<ObjectToPascal<ArrayType>>
-            : Array<ArrayType>
-          : T[K] extends object | undefined | null
-          ? ObjectToPascal<T[K]>
-          : T[K];
-      };
+  ? undefined
+  : T extends null
+  ? null
+  : T extends Array<infer ArrayType extends string | number>
+  ? Array<ArrayType>
+  : T extends Array<infer ArrayType extends object>
+  ? Array<ObjectToPascal<ArrayType>>
+  : T extends Uint8Array
+  ? Uint8Array
+  : T extends Date
+  ? Date
+  : {
+    [K in keyof T as ToPascal<K>]: T[K] extends Array<infer ArrayType extends string | number>
+    ? Array<ArrayType>
+    : T extends Array<infer ArrayType extends object>
+    ? Array<ObjectToPascal<ArrayType>>
+    : T[K] extends object | undefined | null
+    ? ObjectToPascal<T[K]>
+    : T[K];
+  };
 
 export type ToSnake<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}${CapitalChars}${infer Tail}` // string has a capital char somewhere
-    ? Head extends '' // there is a capital char in the first position
-      ? Tail extends ''
-        ? Lowercase<S> /*  'A' */
-        : S extends `${infer Caps}${Tail}` // tail exists, has capital characters
-        ? Caps extends CapitalChars
-          ? Tail extends CapitalLetters
-            ? `${Lowercase<Caps>}_${Lowercase<Tail>}` /* 'AB' */
-            : Tail extends `${CapitalLetters}${string}`
-            ? `${ToSnake<Caps>}_${ToSnake<Tail>}` /* first tail char is upper? 'ABcd' */
-            : `${ToSnake<Caps>}${ToSnake<Tail>}` /* 'AbCD','AbcD',  */ /* TODO: if tail is only numbers, append without underscore */
-          : never /* never reached, used for inference of caps */
-        : never
-      : Tail extends '' /* 'aB' 'abCD' 'ABCD' 'AB' */
-      ? S extends `${Head}${infer Caps}`
-        ? Caps extends CapitalChars
-          ? Head extends Lowercase<Head> /* 'abcD' */
-            ? Caps extends Numbers
-              ? // Head exists and is lowercase, tail does not, Caps is a number, we may be in a sub-select
-                // if head ends with number, don't split head an Caps, keep contiguous numbers together
-                Head extends `${string}${Numbers}`
-                ? never
-                : // head does not end in number, safe to split. 'abc2' -> 'abc_2'
-                  `${ToSnake<Head>}_${Caps}`
-              : `${ToSnake<Head>}_${ToSnake<Caps>}` /* 'abcD' 'abc25' */
-            : never /* stop union type forming */
-          : never
-        : never /* never reached, used for inference of caps */
-      : S extends `${Head}${infer Caps}${Tail}` /* 'abCd' 'ABCD' 'AbCd' 'ABcD' */
-      ? Caps extends CapitalChars
-        ? Head extends Lowercase<Head> /* is 'abCd' 'abCD' ? */
-          ? Tail extends CapitalLetters /* is 'abCD' where Caps = 'C' */
-            ? `${ToSnake<Head>}_${ToSnake<Caps>}_${Lowercase<Tail>}` /* aBCD Tail = 'D', Head = 'aB' */
-            : Tail extends `${CapitalLetters}${string}` /* is 'aBCd' where Caps = 'B' */
-            ? Head extends Numbers
-              ? never /* stop union type forming */
-              : Head extends `${string}${Numbers}`
-              ? never /* stop union type forming */
-              : `${Head}_${ToSnake<Caps>}_${ToSnake<Tail>}` /* 'aBCd' => `${'a'}_${Lowercase<'B'>}_${ToSnake<'Cd'>}` */
-            : `${ToSnake<Head>}_${Lowercase<Caps>}${ToSnake<Tail>}` /* 'aBcD' where Caps = 'B' tail starts as lowercase */
-          : never
-        : never
-      : never
-    : S /* 'abc'  */
+  ? Head extends '' // there is a capital char in the first position
+  ? Tail extends ''
+  ? Lowercase<S> /*  'A' */
+  : S extends `${infer Caps}${Tail}` // tail exists, has capital characters
+  ? Caps extends CapitalChars
+  ? Tail extends CapitalLetters
+  ? `${Lowercase<Caps>}_${Lowercase<Tail>}` /* 'AB' */
+  : Tail extends `${CapitalLetters}${string}`
+  ? `${ToSnake<Caps>}_${ToSnake<Tail>}` /* first tail char is upper? 'ABcd' */
+  : `${ToSnake<Caps>}${ToSnake<Tail>}` /* 'AbCD','AbcD',  */ /* TODO: if tail is only numbers, append without underscore */
+  : never /* never reached, used for inference of caps */
+  : never
+  : Tail extends '' /* 'aB' 'abCD' 'ABCD' 'AB' */
+  ? S extends `${Head}${infer Caps}`
+  ? Caps extends CapitalChars
+  ? Head extends Lowercase<Head> /* 'abcD' */
+  ? Caps extends Numbers
+  ? // Head exists and is lowercase, tail does not, Caps is a number, we may be in a sub-select
+  // if head ends with number, don't split head an Caps, keep contiguous numbers together
+  Head extends `${string}${Numbers}`
+  ? never
+  : // head does not end in number, safe to split. 'abc2' -> 'abc_2'
+  `${ToSnake<Head>}_${Caps}`
+  : `${ToSnake<Head>}_${ToSnake<Caps>}` /* 'abcD' 'abc25' */
+  : never /* stop union type forming */
+  : never
+  : never /* never reached, used for inference of caps */
+  : S extends `${Head}${infer Caps}${Tail}` /* 'abCd' 'ABCD' 'AbCd' 'ABcD' */
+  ? Caps extends CapitalChars
+  ? Head extends Lowercase<Head> /* is 'abCd' 'abCD' ? */
+  ? Tail extends CapitalLetters /* is 'abCD' where Caps = 'C' */
+  ? `${ToSnake<Head>}_${ToSnake<Caps>}_${Lowercase<Tail>}` /* aBCD Tail = 'D', Head = 'aB' */
+  : Tail extends `${CapitalLetters}${string}` /* is 'aBCd' where Caps = 'B' */
+  ? Head extends Numbers
+  ? never /* stop union type forming */
+  : Head extends `${string}${Numbers}`
+  ? never /* stop union type forming */
+  : `${Head}_${ToSnake<Caps>}_${ToSnake<Tail>}` /* 'aBCd' => `${'a'}_${Lowercase<'B'>}_${ToSnake<'Cd'>}` */
+  : `${ToSnake<Head>}_${Lowercase<Caps>}${ToSnake<Tail>}` /* 'aBcD' where Caps = 'B' tail starts as lowercase */
+  : never
+  : never
+  : never
+  : S /* 'abc'  */
   : never;
 
-export type ObjectToSnake<T extends object | undefined | null> =
-  T extends undefined
-    ? undefined
-    : T extends null
-    ? null
-    : T extends Array<infer ArrayType>
-    ? ArrayType extends object
-      ? Array<ObjectToSnake<ArrayType>>
-      : Array<ArrayType>
-    : T extends Uint8Array
-    ? Uint8Array
-    : T extends Date
-    ? Date
-    : {
-        [K in keyof T as ToSnake<K>]: T[K] extends
-          | Array<infer ArrayType>
-          | undefined
-          | null
-          ? ArrayType extends object
-            ? Array<ObjectToSnake<ArrayType>>
-            : Array<ArrayType>
-          : T[K] extends object | undefined | null
-          ? ObjectToSnake<T[K]>
-          : T[K];
-      };
+export type ObjectToSnake<T extends object | undefined | null> = T extends undefined
+  ? undefined
+  : T extends null
+  ? null
+  : T extends Array<infer ArrayType extends string | number>
+  ? Array<ArrayType>
+  : T extends Array<infer ArrayType extends object>
+  ? Array<ObjectToSnake<ArrayType>>
+  : T extends Uint8Array
+  ? Uint8Array
+  : T extends Date
+  ? Date
+  : {
+    [K in keyof T as ToSnake<K>]: T[K] extends Array<infer ArrayType extends string | number>
+    ? Array<ArrayType>
+    : T extends Array<infer ArrayType extends object>
+    ? Array<ObjectToPascal<ArrayType>>
+    : T[K] extends object | undefined | null
+    ? ObjectToSnake<T[K]>
+    : T[K];
+  };
 
 type CapitalLetters =
   | 'A'

--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -231,7 +231,7 @@ export type ObjectToSnake<T extends object | undefined | null> =
         [K in keyof T as ToSnake<K>]: T[K] extends Array<infer ArrayType extends string | number>
           ? Array<ArrayType>
           : T extends Array<infer ArrayType extends object>
-          ? Array<ObjectToPascal<ArrayType>>
+          ? Array<ObjectToSnake<ArrayType>>
           : T[K] extends object | undefined | null
           ? ObjectToSnake<T[K]>
           : T[K];

--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -134,7 +134,7 @@ export type ObjectToCamel<T extends object | undefined | null> =
           : T[K] extends object | undefined | null
           ? ObjectToCamel<T[K]>
           : T[K];
-        };
+      };
 
 export type ToPascal<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`

--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -105,6 +105,15 @@ export function objectToPascal<T extends object>(obj: T): ObjectToPascal<T> {
   return convertObject(obj, toPascal);
 }
 
+type Primitive =
+  | Date
+  | Uint8Array
+  | null
+  | undefined
+  | string
+  | number
+  | boolean;
+
 export type ToCamel<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
     ? `${ToCamel<Uncapitalize<Head>>}${Capitalize<ToCamel<Tail>>}`
@@ -113,28 +122,21 @@ export type ToCamel<S extends string | number | symbol> = S extends string
     : Uncapitalize<S>
   : never;
 
-export type ObjectToCamel<T extends object | undefined | null> =
-  T extends undefined
-    ? undefined
-    : T extends null
-    ? null
-    : T extends Array<infer ArrayType extends string | number>
-    ? Array<ArrayType>
-    : T extends Array<infer ArrayType extends object>
-    ? Array<ObjectToCamel<ArrayType>>
-    : T extends Uint8Array
-    ? Uint8Array
-    : T extends Date
-    ? Date
-    : {
-        [K in keyof T as ToCamel<K>]: T[K] extends Array<infer ArrayType extends string | number>
-          ? Array<ArrayType>
-          : T extends Array<infer ArrayType extends object>
-          ? Array<ObjectToCamel<ArrayType>>
-          : T[K] extends object | undefined | null
-          ? ObjectToCamel<T[K]>
-          : T[K];
-      };
+export type ObjectToCamel<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+  ? Array<
+      U extends Array<infer N>
+        ? N extends Primitive
+          ? U
+          : Array<ObjectToCamel<N>>
+        : ObjectToCamel<U>
+    >
+  : T extends object
+  ? {
+      [K in keyof T as ToCamel<string & K>]: ObjectToCamel<T[K]>;
+    }
+  : T;
 
 export type ToPascal<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
@@ -144,28 +146,21 @@ export type ToPascal<S extends string | number | symbol> = S extends string
     : Capitalize<S>
   : never;
 
-export type ObjectToPascal<T extends object | undefined | null> =
-  T extends undefined
-    ? undefined
-    : T extends null
-    ? null
-    : T extends Array<infer ArrayType extends string | number>
-    ? Array<ArrayType>
-    : T extends Array<infer ArrayType extends object>
-    ? Array<ObjectToPascal<ArrayType>>
-    : T extends Uint8Array
-    ? Uint8Array
-    : T extends Date
-    ? Date
-    : {
-        [K in keyof T as ToPascal<K>]: T[K] extends Array<infer ArrayType extends string | number>
-          ? Array<ArrayType>
-          : T extends Array<infer ArrayType extends object>
-          ? Array<ObjectToPascal<ArrayType>>
-          : T[K] extends object | undefined | null
-          ? ObjectToPascal<T[K]>
-          : T[K];
-      };
+export type ObjectToPascal<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+  ? Array<
+      U extends Array<infer N>
+        ? N extends Primitive
+          ? U
+          : Array<ObjectToPascal<N>>
+        : ObjectToPascal<U>
+    >
+  : T extends object
+  ? {
+      [K in keyof T as ToPascal<string & K>]: ObjectToPascal<T[K]>;
+    }
+  : T;
 
 export type ToSnake<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}${CapitalChars}${infer Tail}` // string has a capital char somewhere
@@ -214,28 +209,21 @@ export type ToSnake<S extends string | number | symbol> = S extends string
     : S /* 'abc'  */
   : never;
 
-export type ObjectToSnake<T extends object | undefined | null> =
-  T extends undefined
-    ? undefined
-    : T extends null
-    ? null
-    : T extends Array<infer ArrayType extends string | number>
-    ? Array<ArrayType>
-    : T extends Array<infer ArrayType extends object>
-    ? Array<ObjectToSnake<ArrayType>>
-    : T extends Uint8Array
-    ? Uint8Array
-    : T extends Date
-    ? Date
-    : {
-        [K in keyof T as ToSnake<K>]: T[K] extends Array<infer ArrayType extends string | number>
-          ? Array<ArrayType>
-          : T extends Array<infer ArrayType extends object>
-          ? Array<ObjectToSnake<ArrayType>>
-          : T[K] extends object | undefined | null
-          ? ObjectToSnake<T[K]>
-          : T[K];
-      };
+export type ObjectToSnake<T> = T extends Primitive
+  ? T
+  : T extends Array<infer U>
+  ? Array<
+      U extends Array<infer N>
+        ? N extends Primitive
+          ? U
+          : Array<ObjectToSnake<N>>
+        : ObjectToSnake<U>
+    >
+  : T extends object
+  ? {
+      [K in keyof T as ToSnake<string & K>]: ObjectToSnake<T[K]>;
+    }
+  : T;
 
 type CapitalLetters =
   | 'A'

--- a/src/caseConvert.ts
+++ b/src/caseConvert.ts
@@ -106,13 +106,13 @@ export function objectToPascal<T extends object>(obj: T): ObjectToPascal<T> {
 }
 
 type Primitive =
+  | boolean
+  | number
+  | string
   | Date
   | Uint8Array
   | null
-  | undefined
-  | string
-  | number
-  | boolean;
+  | undefined;
 
 export type ToCamel<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
@@ -124,19 +124,17 @@ export type ToCamel<S extends string | number | symbol> = S extends string
 
 export type ObjectToCamel<T> = T extends Primitive
   ? T
-  : T extends Array<infer U>
+  : T extends Array<infer ArrayType>
   ? Array<
-      U extends Array<infer N>
-        ? N extends Primitive
-          ? U
-          : Array<ObjectToCamel<N>>
-        : ObjectToCamel<U>
+      ArrayType extends Array<infer InnerArrayType>
+        ? InnerArrayType extends Primitive
+          ? ArrayType
+          : Array<ObjectToCamel<InnerArrayType>>
+        : ObjectToCamel<ArrayType>
     >
-  : T extends object
-  ? {
+  : {
       [K in keyof T as ToCamel<string & K>]: ObjectToCamel<T[K]>;
-    }
-  : T;
+    };
 
 export type ToPascal<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}_${infer Tail}`
@@ -148,19 +146,17 @@ export type ToPascal<S extends string | number | symbol> = S extends string
 
 export type ObjectToPascal<T> = T extends Primitive
   ? T
-  : T extends Array<infer U>
+  : T extends Array<infer ArrayType>
   ? Array<
-      U extends Array<infer N>
-        ? N extends Primitive
-          ? U
-          : Array<ObjectToPascal<N>>
-        : ObjectToPascal<U>
+      ArrayType extends Array<infer InnerArrayType>
+        ? InnerArrayType extends Primitive
+          ? ArrayType
+          : Array<ObjectToPascal<InnerArrayType>>
+        : ObjectToPascal<ArrayType>
     >
-  : T extends object
-  ? {
+  : {
       [K in keyof T as ToPascal<string & K>]: ObjectToPascal<T[K]>;
-    }
-  : T;
+    };
 
 export type ToSnake<S extends string | number | symbol> = S extends string
   ? S extends `${infer Head}${CapitalChars}${infer Tail}` // string has a capital char somewhere
@@ -211,19 +207,17 @@ export type ToSnake<S extends string | number | symbol> = S extends string
 
 export type ObjectToSnake<T> = T extends Primitive
   ? T
-  : T extends Array<infer U>
+  : T extends Array<infer ArrayType>
   ? Array<
-      U extends Array<infer N>
-        ? N extends Primitive
-          ? U
-          : Array<ObjectToSnake<N>>
-        : ObjectToSnake<U>
+      ArrayType extends Array<infer InnerArrayType>
+        ? InnerArrayType extends Primitive
+          ? ArrayType
+          : Array<ObjectToSnake<InnerArrayType>>
+        : ObjectToSnake<ArrayType>
     >
-  : T extends object
-  ? {
+  : {
       [K in keyof T as ToSnake<string & K>]: ObjectToSnake<T[K]>;
-    }
-  : T;
+    };
 
 type CapitalLetters =
   | 'A'

--- a/test/caseConvert.bugs.test.ts
+++ b/test/caseConvert.bugs.test.ts
@@ -159,6 +159,7 @@ interface ArrayTypes {
   arrayOfArrayOfString: string[][];
   optionalArrayOfArrayofString1?: string[][];
   arrayOfOptionalArrayOfString: Array<string[] | undefined>;
+  arrayOfOptionalArrayOfObject: Array<{ prop1: string }[] | undefined>;
 }
 
 type SnakeArrayTypes = ObjectToSnake<ArrayTypes>;
@@ -168,6 +169,7 @@ const _snakeArrays1: SnakeArrayTypes = {
   array_of_array_of_string: [['a']],
   array_of_optional_array_of_string: [['a']],
   optional_array_of_string: ['a'],
+  array_of_optional_array_of_object: [[{ prop_1: '' }]],
 };
 
 const _snakeArrays2: SnakeArrayTypes = {
@@ -175,6 +177,7 @@ const _snakeArrays2: SnakeArrayTypes = {
   array_of_array_of_string: [['a']],
   array_of_optional_array_of_string: [undefined],
   optional_array_of_string: undefined,
+  array_of_optional_array_of_object: [undefined],
 };
 
 const _camelArrays1: ObjectToCamel<ArrayTypes> = {
@@ -182,6 +185,7 @@ const _camelArrays1: ObjectToCamel<ArrayTypes> = {
   arrayOfArrayOfString: [['a']],
   arrayOfOptionalArrayOfString: [['a']],
   optionalArrayOfString: ['a'],
+  arrayOfOptionalArrayOfObject: [[{ prop1: '' }]],
 };
 
 const _camelArrays2: ObjectToCamel<ArrayTypes> = {
@@ -189,6 +193,7 @@ const _camelArrays2: ObjectToCamel<ArrayTypes> = {
   arrayOfArrayOfString: [['a']],
   arrayOfOptionalArrayOfString: [undefined],
   optionalArrayOfString: undefined,
+  arrayOfOptionalArrayOfObject: [undefined],
 };
 
 // Bug #78
@@ -220,4 +225,58 @@ const _pascalDate: ObjectToPascal<{
   MyDate: new Date(),
   ArrDate: [new Date()],
   Nested: { InnerDate: new Date() },
+};
+
+const _snakeStringUnion: ObjectToSnake<{
+  propName: ('a' | 'b' | 'c')[];
+}> = {
+  prop_name: ['a', 'b', 'c'],
+};
+
+const _snakeNumberUnion: ObjectToSnake<{
+  propName: (1 | 2 | 3)[];
+}> = {
+  prop_name: [1, 2, 3],
+};
+
+const _snakeUndefined: ObjectToSnake<{
+  propName: undefined;
+}> = {
+  prop_name: undefined,
+};
+
+const _camelStringUnion: ObjectToCamel<{
+  prop_name: ('a' | 'b' | 'c')[];
+}> = {
+  propName: ['a', 'b', 'c'],
+};
+
+const _camelNumberUnion: ObjectToCamel<{
+  prop_name: (1 | 2 | 3)[];
+}> = {
+  propName: [1, 2, 3],
+};
+
+const _camelUndefined: ObjectToCamel<{
+  prop_name: undefined;
+}> = {
+  propName: undefined,
+};
+
+const _pascalStringUnion: ObjectToPascal<{
+  propName: ('a' | 'b' | 'c')[];
+}> = {
+  PropName: ['a', 'b', 'c'],
+};
+
+const _pascalNumberUnion: ObjectToPascal<{
+  propName: (1 | 2 | 3)[];
+}> = {
+  PropName: [1, 2, 3],
+};
+
+const _pascalUndefined: ObjectToPascal<{
+  propName: undefined;
+}> = {
+  PropName: undefined,
 };


### PR DESCRIPTION
There is an issue with the `ObjectToCamel`, `ObjectToPascal`, `ObjectToSnake` where they don't handle an array of string number unions correctly.

For example, the following:
```ts
ObjectToCamel<{
  prop_name: ("a" | "b" | "c")[];
}>
```

incorrectly returns:
```ts
{
    propName: "a"[] | "b"[] | "c"[];
}
```

when it should return:
```ts
{
    propName: ("a" | "b" | "c")[];
}
```

This PR fixes `ObjectToCamel`, `ObjectToPascal`, `ObjectToSnake` to return the correct string/number union array type.